### PR TITLE
Configure timezone to fix time sync issues

### DIFF
--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -4,6 +4,11 @@ COPY src/composer.* /var/www/laravel-studio/
 
 WORKDIR /var/www/laravel-studio
 
+# Configure timezone to avoid time sync issues
+RUN rm /etc/localtime
+RUN ln -s /usr/share/zoneinfo/Europe/London /etc/localtime
+RUN "date"
+
 # System dependencies
 RUN apt-get update && apt-get install -y \
     build-essential \


### PR DESCRIPTION
There is an issue with the system time on Docker containers being out of sync with the host, which causes installs from Debian repositories to fail.

Example:
```
E: Release file for http://security.debian.org/debian-security/dists/buster/updates/InRelease is not valid yet (invalid for another 3h 18min 21s). Updates for this repository will not be applied.
```

The solution is to update the local time on the Docker container.

See:
https://stackoverflow.com/questions/45587214/configure-timezone-in-dockerized-nginx-php-fpm